### PR TITLE
Update README.md - Replaced Sublist3r with updated fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Lorem ipsum dolor sit amet
 
 ### Subdomain Enumeration
 
-- [Sublist3r](https://github.com/aboul3la/Sublist3r) - Fast subdomains enumeration tool for penetration testers
+- [Sublist3r](https://github.com/huntergregal/Sublist3r) - Fast subdomains enumeration tool for penetration testers
 - [Amass](https://github.com/OWASP/Amass) - In-depth Attack Surface Mapping and Asset Discovery
 - [massdns](https://github.com/blechschmidt/massdns) - A high-performance DNS stub resolver for bulk lookups and reconnaissance (subdomain enumeration)
 - [Findomain](https://github.com/Findomain/Findomain) - The fastest and cross-platform subdomain enumerator, do not waste your time.


### PR DESCRIPTION
The Sublist3r in the list is an abandoned project that no longer works. Updated the list with a fork that has fixed many of the issues with the abandoned project.