### PR TITLE
Remove "Lorem ipsum dolor sit amet" sample text

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@
 
 ## Recon
 
-Lorem ipsum dolor sit amet
-
 ### Subdomain Enumeration
 
 - [Sublist3r](https://github.com/aboul3la/Sublist3r) - Fast subdomains enumeration tool for penetration testers


### PR DESCRIPTION
The following text was directly below the Recon heading:

"Lorem ipsum dolor sit amet"

I removed it as I believe it is unnecessary sample text