### PR TITLE
Add wayparam tool to Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [Arjun](https://github.com/s0md3v/Arjun) - HTTP parameter discovery suite.
 - [ParamSpider](https://github.com/devanshbatham/ParamSpider) - Mining parameters from dark corners of Web Archives.
 - [x8](https://github.com/Sh1Yo/x8) - Hidden parameters discovery suite written in Rust.
+- [wayparam](https://github.com/aleff-github/wayparam) - Fetch and normalize parameterized URLs from the Wayback CDX API (OSINT, inspired by ParamSpider).
 
 ### Fuzzing
 


### PR DESCRIPTION
I’m releasing wayparam, a cross-platform Python CLI inspired by ParamSpider. It fetches historical URLs from the Wayback CDX API, filters “boring” static assets, and outputs normalized parameterized URLs (with masked values) in txt or JSONL. It’s pipeline-friendly (stdout clean, diagnostics on stderr), includes a man page, and ships with offline httpx-level integration tests (MockTransport).