### PR TITLE
Add certgrep and Have I Been Squatted tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 ### Subdomain Enumeration
 
 - [Sublist3r](https://github.com/aboul3la/Sublist3r) - Fast subdomains enumeration tool for penetration testers
+- [Have I Been Squatted](https://haveibeensquatted.com) - A fast domain typosquatting detection tool
 - [Amass](https://github.com/OWASP/Amass) - In-depth Attack Surface Mapping and Asset Discovery
 - [massdns](https://github.com/blechschmidt/massdns) - A high-performance DNS stub resolver for bulk lookups and reconnaissance (subdomain enumeration)
 - [Findomain](https://github.com/Findomain/Findomain) - The fastest and cross-platform subdomain enumerator, do not waste your time.
@@ -68,6 +69,7 @@
 - [shuffledns](https://github.com/projectdiscovery/shuffledns) - shuffleDNS is a wrapper around massdns written in go that allows you to enumerate valid subdomains using active bruteforce as well as resolve subdomains with wildcard handling and easy input-output…
 - [puredns](https://github.com/d3mondev/puredns) - Fast domain resolver and subdomain bruteforcing with accurate wildcard filtering with wildcard(*)
 - [censys-subdomain-finder](https://github.com/christophetd/censys-subdomain-finder) - Perform subdomain enumeration using the certificate transparency logs from Censys.
+- [certgrep](https://certgrep.sh) - A fast Certificate Transparency Log regex domain lookup tool
 - [Turbolist3r](https://github.com/fleetcaptain/Turbolist3r) - Subdomain enumeration tool with analysis features for discovered domains
 - [censys-enumeration](https://github.com/0xbharath/censys-enumeration) - A script to extract subdomains/emails for a given domain using SSL/TLS certificate dataset on Censys
 - [tugarecon](https://github.com/LordNeoStark/tugarecon) - Fast subdomains enumeration tool for penetration testers.


### PR DESCRIPTION
## Changes

This PR adds two new tools to the subdomain enumeration section:

- **[certgrep](https://certgrep.sh)** - A fast Certificate Transparency Log regex domain lookup tool
- **[Have I Been Squatted](https://haveibeensquatted.com)** - A fast domain typosquatting detection tool

These tools are valuable additions for bug bounty hunters and penetration testers.