### PR TITLE
Add nullsec-webscan to Vulnerability Scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@
 - [OWASP ZAP](https://github.com/zaproxy/zaproxy) -  World’s most popular free web security tools and is actively maintained by a dedicated international team of volunteers
 - [SSTImap](https://github.com/vladko312/SSTImap) -  SSTImap is a penetration testing software that can check websites for Code Injection and Server-Side Template Injection vulnerabilities and exploit them, giving access to the operating system itself.
 - [Lonkero](https://github.com/bountyyfi/lonkero) - Enterprise-grade web vulnerability scanner with 60+ attack modules, built in Rust for penetration testing and security assessments.
+- [nullsec-webscan](https://github.com/bad-antics/nullsec-webscan) - Web vulnerability scanner with automated reconnaissance, SQL injection, XSS, and SSRF detection for bug bounty hunters.
 
 ### Forbidden Bypass
 


### PR DESCRIPTION
## Description

Adding [nullsec-webscan](https://github.com/bad-antics/nullsec-webscan) to the Vulnerability Scanners section.

## About nullsec-webscan

A web vulnerability scanner designed for bug bounty hunters featuring:
- Automated reconnaissance and target enumeration
- SQL injection detection and exploitation
- XSS (reflected, stored, DOM-based) scanning
- SSRF vulnerability detection
- Fast parallel scanning with customizable templates

Complements existing tools like nuclei and Sn1per with focused web app vulnerability detection.

Thank you for maintaining this excellent bug bounty resource!