### PR TITLE
Add PageGuard - Free website health scanner for bug bounty

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@
 - [OWASP ZAP](https://github.com/zaproxy/zaproxy) -  World’s most popular free web security tools and is actively maintained by a dedicated international team of volunteers
 - [SSTImap](https://github.com/vladko312/SSTImap) -  SSTImap is a penetration testing software that can check websites for Code Injection and Server-Side Template Injection vulnerabilities and exploit them, giving access to the operating system itself.
 - [Lonkero](https://github.com/bountyyfi/lonkero) - Enterprise-grade web vulnerability scanner with 60+ attack modules, built in Rust for penetration testing and security assessments.
+- [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Free website health scanner providing automated SEO audit, performance analysis, WCAG 2.1 accessibility scanning, and AI-powered action plans. Open source (MIT): https://github.com/sleepyxpad-jpg/pageguard
 
 
 ### Permutation


### PR DESCRIPTION
Add PageGuard to the Vulnerability Scanners section.

PageGuard is a free, no-login-required website health scanner useful for bug bounty hunters:
- SEO audit (meta tags, structured data, Core Web Vitals via PageSpeed API)
- Performance analysis
- WCAG 2.1 accessibility compliance testing
- AI-powered action plan generation (Llama 3.1)

PageGuard helps security researchers and bug bounty hunters quickly assess website quality across multiple dimensions (security, performance, accessibility).

Details:
- Free and open source (MIT)
- Instant scan (~30 seconds)
- Live: https://pageguard.qiudeqiu.workers.dev
- Source: https://github.com/sleepyxpad-jpg/pageguard