### PR TITLE
Add Pentest Mindmap — interactive command reference for bug bounty hu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@
 - [jsleak](https://github.com/byt3hx/jsleak) - jsleak is a tool to find secret , paths or links in JavaScript files or source code.
 - [jsfinder](https://github.com/kacakb/jsfinder) - A tool that scans web pages to find JavaScript file URLs linked in the HTML source code.
 - [jsluice](https://github.com/BishopFox/jsluice) - This tool extracts URLs, paths, secrets, and other interesting bits from JavaScript files. Values are extracted based not just on how they look, but also based on how they are used.
-
+- [Pentest Mindmap](https://pentestmindmap.com/en) - Interactive mindmap with 11,600+ pentesting commands across 32 categories. Searchable with one-click copy.
 ### Parameters
 
 - [parameth](https://github.com/maK-/parameth) - This tool can be used to brute discover GET and POST parameters


### PR DESCRIPTION
…nters

Adding Pentest Mindmap — an interactive web-based mindmap with 11,600+ pentesting commands organized across 32 categories.

A searchable, visual reference tool for pentesters. Commands are organized in a D3.js interactive mindmap covering recon, web hacking, AD, privesc, cloud, post-exploitation, and 26 more categories. Each command includes a description.

Trilingual (EN/FR/ES). Free 7-day trial available.

# Description

Please explain the changes you made here:

- foo

## Notes

Please add screenshots or some additional context if you believe it is needed.

## Checklist

- [ ] Only GitHub links to open-source repos are added
- [ ] No duplicate links are added
- [ ] All repos exist and are public
- [ ] All repos have at least 50 stars
