### PR TITLE
Add keyFinder to Secrets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@
 - [SecretFinder](https://github.com/m4ll0k/SecretFinder) - A python script for finding sensitive data (apikeys, accesstoken,jwt,..) and search anything on javascript files.
 - [js-snitch](https://github.com/vavkamil/js-snitch) - Scans remote JavaScript files with Trufflehog + Semgrep to detect leaked secrets.
 - [keyhacks](https://github.com/streaak/keyhacks) - KeyHacks shows methods to validate different API keys found on a Bug Bounty Program or a pentest.
+- [keyFinder](https://github.com/momenbasel/keyFinder) - A Chrome extension that passively scans web pages for API keys, tokens, and secrets using 80+ regex patterns and Shannon entropy analysis across 10 attack surfaces.
 
 
 ### Git


### PR DESCRIPTION
## Summary

- Adds [keyFinder](https://github.com/momenbasel/keyFinder) to the **Secrets** section.
- keyFinder is a Chrome extension (MIT license, 556 stars) that passively scans every web page for leaked API keys, tokens, and secrets using 80+ regex detection patterns and Shannon entropy analysis across 10 attack surfaces (AWS, GCP, Stripe, Slack, etc.). Zero dependencies, Manifest V3.