### PR TITLE
Add ContrastAPI to Subdomain Enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [Findomain](https://github.com/Findomain/Findomain) - The fastest and cross-platform subdomain enumerator, do not waste your time.
 - [Sudomy](https://github.com/Screetsec/Sudomy) - Sudomy is a subdomain enumeration tool to collect subdomains and analyzing domains performing automated reconnaissance (recon) for bug hunting / pentesting
 - [chaos-client](https://github.com/projectdiscovery/chaos-client) - Go client to communicate with Chaos DNS API.
+- [ContrastAPI](https://github.com/contrastcyber/contrastapi) - All-in-one recon API that combines subdomain enumeration, DNS, WHOIS, and SSL checks in a single query
 - [domained](https://github.com/TypeError/domained) - Multi Tool Subdomain Enumeration
 - [bugcrowd-levelup-subdomain-enumeration](https://github.com/appsecco/bugcrowd-levelup-subdomain-enumeration) - This repository contains all the material from the talk "Esoteric sub-domain enumeration techniques" given at Bugcrowd LevelUp 2017 virtual conference
 - [shuffledns](https://github.com/projectdiscovery/shuffledns) - shuffleDNS is a wrapper around massdns written in go that allows you to enumerate valid subdomains using active bruteforce as well as resolve subdomains with wildcard handling and easy input-output…


### PR DESCRIPTION
Adds [ContrastAPI](https://github.com/contrastcyber/contrastapi) to the Subdomain Enumeration section.

It's a free security intelligence API that bundles subdomain enumeration, DNS, WHOIS, and SSL checks into a single endpoint — handy for recon without juggling multiple tools.