### PR TITLE
Add Snaplert to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@
 
 - [bbscope](https://github.com/sw33tLie/bbscope) - Scope aggregation tool for HackerOne, Bugcrowd, Intigriti, YesWeHack, Immunefi
 - [jsmon](https://github.com/robre/jsmon) - A Javascript change monitoring tool for Bug Bounty.
+- [Snaplert](https://snaplert.com) - Hosted website change monitoring with AI-powered visual diffs, element-level zone picker, and email alerts with before/after screenshots.
 
 ---
 


### PR DESCRIPTION
## What's being added

[Snaplert](https://snaplert.com) — hosted website change monitoring with AI-powered visual diffs, element-level zone picker, and email alerts with before/after screenshots.

## Why it fits here

Bug bounty hunters frequently monitor target pages for changes (new endpoints, updated scope, policy changes, feature rollouts). Snaplert is a hosted alternative to self-hosted solutions like jsmon — no setup required, free during open beta, with 5-minute check intervals and AI summaries explaining what changed.

Fits the existing Monitoring section alongside jsmon (JS change monitoring) and bbscope (scope aggregation).