### PR TITLE
Add nextscope - JS bundle API endpoint discovery tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
 - [jsleak](https://github.com/byt3hx/jsleak) - jsleak is a tool to find secret , paths or links in JavaScript files or source code.
 - [jsfinder](https://github.com/kacakb/jsfinder) - A tool that scans web pages to find JavaScript file URLs linked in the HTML source code.
 - [jsluice](https://github.com/BishopFox/jsluice) - This tool extracts URLs, paths, secrets, and other interesting bits from JavaScript files. Values are extracted based not just on how they look, but also based on how they are used.
+- [nextscope](https://github.com/burhanmoin1/nextscope) - Automated API endpoint discovery via JS chunk interception
 
 ### Parameters
 


### PR DESCRIPTION
Adding nextscope, a recon tool that discovers API endpoints by intercepting 
Next.js/React JS bundle chunks in real-time using a headless browser.

- No wordlist required
- Works against Next.js, React, Vue, Nuxt
- Extracts hardcoded /api/ paths from lazy-loaded chunks
- Optional endpoint probing with status codes

https://github.com/burhanmoin1/nextscope