### PR TITLE
Add invisible-playwright to Recon/Screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - [scrying](https://github.com/nccgroup/scrying) - A tool for collecting RDP, web and VNC screenshots all in one place
 - [Depix](https://github.com/beurtschipper/Depix) - Recovers passwords from pixelized screenshots
 - [httpscreenshot](https://github.com/breenmachine/httpscreenshot/) - HTTPScreenshot is a tool for grabbing screenshots and HTML of large numbers of websites.
+- [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Playwright wrapper for a stealth-patched Firefox 150 binary, useful for screenshotting and recon against targets with anti-bot detection (reCAPTCHA v3, FingerprintPro, Cloudflare).
 
 ### Technologies
 


### PR DESCRIPTION
Playwright wrapper for a stealth-patched Firefox 150 binary. Returns a native Playwright Browser, so it slots into any existing recon pipeline that does browser-based screenshotting or DOM scraping. Anti-fingerprinting lives in the C++ source (Canvas, WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection) so targets guarded by reCAPTCHA v3, FingerprintPro, or Cloudflare don't trip the usual anti-bot heuristics.

Useful when WitnessMe / gowitness get blocked or returned dummy content. Same workflow, different binary.

Repo: https://github.com/feder-cr/invisible_playwright
Patches: https://github.com/feder-cr/firefox-stealth