### PR TITLE
Add reconsentry to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@
 
 - [bbscope](https://github.com/sw33tLie/bbscope) - Scope aggregation tool for HackerOne, Bugcrowd, Intigriti, YesWeHack, Immunefi
 - [jsmon](https://github.com/robre/jsmon) - A Javascript change monitoring tool for Bug Bounty.
+- [reconsentry](https://github.com/maruftak/reconsentry) - Continuous attack-surface change monitor that alerts when a new subdomain, live host, endpoint, or technology appears on authorized targets.
 
 ---
 


### PR DESCRIPTION
Adds [reconsentry](https://github.com/maruftak/reconsentry) to the Monitoring section.

It's a continuous attack-surface change monitor: snapshots an authorized scope (subfinder/httpx, optional katana/nuclei), diffs against the previous run, prioritizes changes (NEW_HOST, HOST_LIVE, STATUS_CHANGE, NEW_ENDPOINT, NEW_TECH, …), and alerts via webhook/Slack/Discord/Telegram/email. Single Go binary, MIT, includes a passive mode for scopes that forbid active scanning.

Entry follows the existing format and alphabetical order in the section.