### PR TITLE
Add ARS3NAL - offline pentest & bug-bounty arsenal

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@
 
 ## Uncategorized
 
+- [ARS3NAL](https://github.com/inflictx/Arsenal) - Offline-first, searchable arsenal for pentest & bug bounty: ~1500 payloads, a click-to-build command generator, GTFOBins, wordlists, an embedded CyberChef, reverse shells and 70 checklists. Self-hosted web app with a live static demo.
 - [RF Swift](https://github.com/PentHertz/RF-Swift) - A powerful multi-platform RF toolbox that deploys specialized radio tools in seconds on Linux, Windows, and macOS—supporting x86_64, ARM64 (Raspberry Pi, Apple Silicon), and RISC-V architectures without disrupting your primary OS.
 - [bountyplz](https://github.com/fransr/bountyplz) - Automated security reporting from markdown templates (HackerOne and Bugcrowd are currently the platforms supported)
 - [PayloadsAllTheThings](https://github.com/swisskyrepo/PayloadsAllTheThings) - A list of useful payloads and bypass for Web Application Security and Pentest/CTF


### PR DESCRIPTION
Adds **ARS3NAL** to the list.

ARS3NAL is an offline-first, searchable arsenal for pentesting and bug bounty: ~1500 payloads, a click-to-build command generator, GTFOBins, a wordlists reference, an embedded CyberChef, a reverse-shell generator, 70 interactive checklists and an engagement/findings tracker. It is a self-hosted web app and also ships a static live demo. Open-source, GPL-3.0, bilingual EN/RU.

- Repo: https://github.com/inflictx/Arsenal
- Live demo: https://inflictx.github.io/Arsenal/