### PR TITLE
ci: fix fork PR README diff base

### DIFF
--- a/.github/workflows/stargazers.yml
+++ b/.github/workflows/stargazers.yml
@@ -24,14 +24,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Fetch base branch
-        run: |
-          git fetch origin main --depth=1
-
       - name: Extract newly added URLs and GitHub repo links
         run: |
-          # Show diff between base branch and PR HEAD, only for README
-          git diff --unified=0 origin/main...HEAD -- README.md > diff.txt
+          # On pull_request, HEAD is GitHub's synthetic merge commit and HEAD^1 is the base.
+          git diff --unified=0 HEAD^1 HEAD -- README.md > diff.txt
 
           # Extract ALL added https:// URLs from added (+) lines
           sed -n 's/^+.*\(https:\/\/[^ )]*\).*/\1/p' diff.txt \


### PR DESCRIPTION
# Description

Fixes the Stargazers workflow so fork pull requests do not fail README link detection when the fork branch is behind `main`.

- remove the shallow `origin main` refetch that could leave the runner without a merge base
- diff the checked-out pull request merge commit against its first parent, which is the base side of the merge

## Notes

This keeps the workflow on the `pull_request` trigger with read-only permissions and `persist-credentials: false`.

## Checklist

- [ ] Only GitHub links to open-source repos are added
- [ ] No duplicate links are added
- [ ] All repos exist and are public
- [ ] All repos have at least 50 stars
