### PR TITLE
Add hetty proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@
 - [proxify](https://github.com/projectdiscovery/proxify) - A versatile and portable proxy for capturing, manipulating, and replaying HTTP/HTTPS traffic on the go.
 - [FoxyProxy Browser Extension](https://github.com/foxyproxy/browser-extension) - FoxyProxy is an open-source, advanced proxy management tool that completely replaces Chrome's limited proxying capabilities.
 - [zaproxy](https://github.com/zaproxy/zaproxy) - ZAP is what is known as a “manipulator-in-the-middle proxy.” It stands between the tester’s browser and the web application so that it can intercept and inspect messages sent between browser and web application, modify the contents if needed, and then forward those packets on to the destination.
-- [hetty](https://hetty.xyz) - hetty is a free opensource alternative to Burpsuite pro
+- [hetty](https://github.com/dstotijn/hetty) - hetty is a free opensource alternative to Burpsuite pro
 
 ### Origin IP
 

--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@
 - [proxify](https://github.com/projectdiscovery/proxify) - A versatile and portable proxy for capturing, manipulating, and replaying HTTP/HTTPS traffic on the go.
 - [FoxyProxy Browser Extension](https://github.com/foxyproxy/browser-extension) - FoxyProxy is an open-source, advanced proxy management tool that completely replaces Chrome's limited proxying capabilities.
 - [zaproxy](https://github.com/zaproxy/zaproxy) - ZAP is what is known as a “manipulator-in-the-middle proxy.” It stands between the tester’s browser and the web application so that it can intercept and inspect messages sent between browser and web application, modify the contents if needed, and then forward those packets on to the destination.
+- [hetty](https://hetty.xyz) - hetty is a free opensource alternative to Burpsuite pro
 
 ### Origin IP
 


### PR DESCRIPTION
# Description

Please explain the changes you made here:

Added Hetty proxy to web proxy and traffic interception section
```
- [hetty](https://github.com/dstotijn/hetty) - hetty is a free opensource alternative to Burpsuite pro
```

## Notes

Please add screenshots or some additional context if you believe it is needed.

## Checklist

- [x] Only GitHub links to open-source repos are added
- [x] No duplicate links are added
- [x] All repos exist and are public
- [x] All repos have at least 50 stars
