### PR TITLE
Add Agentic Bug Bounty Hunter to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@
 - [shannon](https://github.com/KeygraphHQ/shannon) - Fully autonomous AI hacker to find actual exploits in your web apps.
 - [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform that orchestrates 80+ tools over MCP with dedicated per-technology offensive sub-agents (GraphQL, Spring Boot, ASP.NET, Node.js, Flask, PHP, Ruby) and a per-finding evidence trail.
 - [PentestGPT](https://github.com/GreyDGL/PentestGPT) - AI-powered penetration testing assistant that helps automate security testing workflows and vulnerability discovery.
+- [Agentic Bug Bounty Hunter](https://github.com/Awarexone/Agentic-Bug-Hunter) - Claude Code plugin for autonomous bug bounty hunting across HackerOne, Bugcrowd, Intigriti and Immunefi — 15 skills, 33 commands and 9 agents covering recon-to-report, 21 web vuln classes, web3/meme-coin audits, LLM red-teaming, GraphQL/CORS/JWT/NoSQL scanners and persistent hunt memory. Works with or without a subscription.
 
 ---
 


### PR DESCRIPTION
Adds **Agentic Bug Bounty Hunter** to the **AI Agents** section.

- Repo: https://github.com/Awarexone/Agentic-Bug-Hunter (open-source, 4.6k+ stars)
- What it is: a Claude Code plugin for professional bug bounty hunting across HackerOne, Bugcrowd, Intigriti and Immunefi.
- Scope: 15 skills, 33 slash commands and 9 specialized agents covering the full recon-to-report workflow, 21 web vuln classes, web3 / meme-coin smart-contract audits, LLM red-teaming, and dedicated GraphQL / CORS / CRLF / JWT / NoSQL / OOB scanners, backed by a persistent cross-target hunt memory.
- Works with or without a Claude subscription.

Single-line addition, style matches the existing AI Agents entries.